### PR TITLE
Add tagging support for OUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each OU is represented as a map with attributes
 - `name_path` - Path to the OU using OU names, delimited by the `name_path_delimiter` variable.
 - `org_path` - Path to the OU from the Organization ID, to be used with the `aws:PrincipalOrgPaths` and `aws:ResourceOrgPaths` IAM conditions.
 - `parent_id` - ID of the OU's direct parent.
+- `tags` - Map of tags associated with the OU. Dependent upon the `include_ou_tags` or `organization_structure` variables.
 
 ## Usage
 
@@ -109,13 +110,12 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version   |
-| ------------------------------------------------------------------------ | --------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.10.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 4.55.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.55.0 |
 
 ## Providers
 
@@ -123,10 +123,10 @@ No providers.
 
 ## Modules
 
-| Name                                                        | Source             | Version |
-| ----------------------------------------------------------- | ------------------ | ------- |
-| <a name="module_data"></a> [data](#module_data)             | ./modules/data     | n/a     |
-| <a name="module_resource"></a> [resource](#module_resource) | ./modules/resource | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_data"></a> [data](#module\_data) | ./modules/data | n/a |
+| <a name="module_resource"></a> [resource](#module\_resource) | ./modules/resource | n/a |
 
 ## Resources
 
@@ -134,21 +134,22 @@ No resources.
 
 ## Inputs
 
-| Name                                                                                                               | Description                                                                                                   | Type     | Default | Required |
-| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------- | ------- | :------: |
-| <a name="input_include_child_accounts"></a> [include_child_accounts](#input_include_child_accounts)                | Include direct child AWS accounts in the output, increases the number of API calls when enabled.              | `bool`   | `false` |    no    |
-| <a name="input_include_descendant_accounts"></a> [include_descendant_accounts](#input_include_descendant_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled.                             | `bool`   | `false` |    no    |
-| <a name="input_name_path_delimiter"></a> [name_path_delimiter](#input_name_path_delimiter)                         | Delimiter used to join names in the name_path attribute of each OU.                                           | `string` | `"/"`   |    no    |
-| <a name="input_organization_structure"></a> [organization_structure](#input_organization_structure)                | The structure of OUs to manage as a map of maps. If not provided, this module will function as a data source. | `any`    | `{}`    |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_include_child_accounts"></a> [include\_child\_accounts](#input\_include\_child\_accounts) | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
+| <a name="input_include_descendant_accounts"></a> [include\_descendant\_accounts](#input\_include\_descendant\_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled. | `bool` | `false` | no |
+| <a name="input_include_ou_tags"></a> [include\_ou\_tags](#input\_include\_ou\_tags) | Include tags for each OU in the output, increases the number of API calls when enabled. Has no effect when organization\_structure is provided. | `bool` | `false` | no |
+| <a name="input_name_path_delimiter"></a> [name\_path\_delimiter](#input\_name\_path\_delimiter) | Delimiter used to join names in the name\_path attribute of each OU. | `string` | `"/"` | no |
+| <a name="input_organization_structure"></a> [organization\_structure](#input\_organization\_structure) | The structure of OUs to manage as a map of maps. If not provided, this module will function as a data source. | `any` | `{}` | no |
+| <a name="input_ou_tags_key"></a> [ou\_tags\_key](#input\_ou\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. | `string` | `null` | no |
 
 ## Outputs
 
-| Name                                                                    | Description                                               |
-| ----------------------------------------------------------------------- | --------------------------------------------------------- |
-| <a name="output_by_id"></a> [by_id](#output_by_id)                      | Map of OUs indexed by id.                                 |
-| <a name="output_by_name_path"></a> [by_name_path](#output_by_name_path) | Map of OUs indexed by name_path.                          |
-| <a name="output_list"></a> [list](#output_list)                         | List of OUs with added attributes name_path and org_path. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_by_id"></a> [by\_id](#output\_by\_id) | Map of OUs indexed by id. |
+| <a name="output_by_name_path"></a> [by\_name\_path](#output\_by\_name\_path) | Map of OUs indexed by name\_path. |
+| <a name="output_list"></a> [list](#output\_list) | List of OUs with added attributes name\_path and org\_path. |
 <!-- END_TF_DOCS -->
 
 ## About The National Archives, UK

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An open-source Terraform module to create and/or expose AWS Organizations Organi
 - Can be used as a **resource** or **data source** with the same outputs.
 - Supports up to **5 levels** of Organizational Units (AWS Quota).
 - Define your organization structure as a map.
+- Tag each OU and cascade tags to child OUs.
 - Generates OrgPaths, to be used with the `aws:PrincipalOrgPaths` and `aws:ResourceOrgPaths` IAM conditions.
 - Organizational Units are exposed via a list and indexed maps, see <a name="Outputs"></a> [Outputs](#Outputs) for more information.
 
@@ -136,12 +137,13 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cascading_tags_key"></a> [cascading\_tags\_key](#input\_cascading\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. These tags will cascade to child OUs if the same key isn't defined on a nested OU. | `string` | `""` | no |
 | <a name="input_include_child_accounts"></a> [include\_child\_accounts](#input\_include\_child\_accounts) | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
 | <a name="input_include_descendant_accounts"></a> [include\_descendant\_accounts](#input\_include\_descendant\_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled. | `bool` | `false` | no |
 | <a name="input_include_ou_tags"></a> [include\_ou\_tags](#input\_include\_ou\_tags) | Include tags for each OU in the output, increases the number of API calls when enabled. Has no effect when organization\_structure is provided. | `bool` | `false` | no |
 | <a name="input_name_path_delimiter"></a> [name\_path\_delimiter](#input\_name\_path\_delimiter) | Delimiter used to join names in the name\_path attribute of each OU. | `string` | `"/"` | no |
 | <a name="input_organization_structure"></a> [organization\_structure](#input\_organization\_structure) | The structure of OUs to manage as a map of maps. If not provided, this module will function as a data source. | `any` | `{}` | no |
-| <a name="input_ou_tags_key"></a> [ou\_tags\_key](#input\_ou\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. | `string` | `null` | no |
+| <a name="input_static_tags_key"></a> [static\_tags\_key](#input\_static\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags on the OU. | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,8 @@ module "resource" {
   include_descendant_accounts = var.include_descendant_accounts
   name_path_delimiter         = var.name_path_delimiter
   organization_structure      = var.organization_structure
-  ou_tags_key                 = var.ou_tags_key
+  cascading_tags_key          = var.cascading_tags_key
+  static_tags_key             = var.static_tags_key
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ module "data" {
 
   include_child_accounts      = var.include_child_accounts
   include_descendant_accounts = var.include_descendant_accounts
+  include_ou_tags             = var.include_ou_tags
   name_path_delimiter         = var.name_path_delimiter
 }
 
@@ -19,6 +20,7 @@ module "resource" {
   include_descendant_accounts = var.include_descendant_accounts
   name_path_delimiter         = var.name_path_delimiter
   organization_structure      = var.organization_structure
+  ou_tags_key                 = var.ou_tags_key
 }
 
 locals {

--- a/modules/data/README.md
+++ b/modules/data/README.md
@@ -25,6 +25,7 @@ Each OU is represented as a map with attributes
 - `name_path` - Path to the OU using OU names, delimited by the `name_path_delimiter` variable.
 - `org_path` - Path to the OU from the Organization ID, to be used with the `aws:PrincipalOrgPaths` and `aws:ResourceOrgPaths` conditions.
 - `parent_id` - ID of the OU's direct parent.
+- `tags` - Map of tags associated with the OU. Dependent upon the `include_ou_tags` variable.
 
 ## Usage
 
@@ -66,50 +67,49 @@ resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version   |
-| ------------------------------------------------------------------------ | --------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9.0  |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 4.55.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.55.0 |
 
 ## Providers
 
-| Name                                             | Version   |
-| ------------------------------------------------ | --------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | >= 4.55.0 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.55.0 |
 
 ## Modules
 
-| Name                                      | Source                | Version |
-| ----------------------------------------- | --------------------- | ------- |
-| <a name="module_l1"></a> [l1](#module_l1) | ./modules/get_sub_ous | n/a     |
-| <a name="module_l2"></a> [l2](#module_l2) | ./modules/get_sub_ous | n/a     |
-| <a name="module_l3"></a> [l3](#module_l3) | ./modules/get_sub_ous | n/a     |
-| <a name="module_l4"></a> [l4](#module_l4) | ./modules/get_sub_ous | n/a     |
-| <a name="module_l5"></a> [l5](#module_l5) | ./modules/get_sub_ous | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_l1"></a> [l1](#module\_l1) | ./modules/get_sub_ous | n/a |
+| <a name="module_l2"></a> [l2](#module\_l2) | ./modules/get_sub_ous | n/a |
+| <a name="module_l3"></a> [l3](#module\_l3) | ./modules/get_sub_ous | n/a |
+| <a name="module_l4"></a> [l4](#module\_l4) | ./modules/get_sub_ous | n/a |
+| <a name="module_l5"></a> [l5](#module\_l5) | ./modules/get_sub_ous | n/a |
 
 ## Resources
 
-| Name                                                                                                                                            | Type        |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Name | Type |
+|------|------|
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs
 
-| Name                                                                                                               | Description                                                                                      | Type     | Default | Required |
-| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------- | ------- | :------: |
-| <a name="input_include_child_accounts"></a> [include_child_accounts](#input_include_child_accounts)                | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool`   | `false` |    no    |
-| <a name="input_include_descendant_accounts"></a> [include_descendant_accounts](#input_include_descendant_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled.                | `bool`   | `false` |    no    |
-| <a name="input_name_path_delimiter"></a> [name_path_delimiter](#input_name_path_delimiter)                         | Delimiter used to join names in the name_path attribute of each OU.                              | `string` | `"/"`   |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_include_child_accounts"></a> [include\_child\_accounts](#input\_include\_child\_accounts) | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
+| <a name="input_include_descendant_accounts"></a> [include\_descendant\_accounts](#input\_include\_descendant\_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled. | `bool` | `false` | no |
+| <a name="input_include_ou_tags"></a> [include\_ou\_tags](#input\_include\_ou\_tags) | Include tags for each OU in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
+| <a name="input_name_path_delimiter"></a> [name\_path\_delimiter](#input\_name\_path\_delimiter) | Delimiter used to join names in the name\_path attribute of each OU. | `string` | `"/"` | no |
 
 ## Outputs
 
-| Name                                                                    | Description                                                   |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------- |
-| <a name="output_by_id"></a> [by_id](#output_by_id)                      | Map of all OUs indexed by id.                                 |
-| <a name="output_by_name_path"></a> [by_name_path](#output_by_name_path) | Map of all OUs indexed by name_path.                          |
-| <a name="output_list"></a> [list](#output_list)                         | List of all OUs with added attributes name_path and org_path. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_by_id"></a> [by\_id](#output\_by\_id) | Map of all OUs indexed by id. |
+| <a name="output_by_name_path"></a> [by\_name\_path](#output\_by\_name\_path) | Map of all OUs indexed by name\_path. |
+| <a name="output_list"></a> [list](#output\_list) | List of all OUs with added attributes name\_path and org\_path. |
 <!-- END_TF_DOCS -->

--- a/modules/data/main.tf
+++ b/modules/data/main.tf
@@ -9,6 +9,7 @@ locals {
 module "l1" {
   source               = "./modules/get_sub_ous"
   include_aws_accounts = var.include_child_accounts
+  include_ou_tags      = var.include_ou_tags
   name_path_delimiter  = var.name_path_delimiter
   # Mock a "level0_ous" module output for the root.
   parent_level_ou_list = [{
@@ -21,6 +22,7 @@ module "l1" {
 module "l2" {
   source               = "./modules/get_sub_ous"
   include_aws_accounts = var.include_child_accounts
+  include_ou_tags      = var.include_ou_tags
   name_path_delimiter  = var.name_path_delimiter
   parent_level_ou_list = module.l1.list
 }
@@ -28,6 +30,7 @@ module "l2" {
 module "l3" {
   source               = "./modules/get_sub_ous"
   include_aws_accounts = var.include_child_accounts
+  include_ou_tags      = var.include_ou_tags
   name_path_delimiter  = var.name_path_delimiter
   parent_level_ou_list = module.l2.list
 }
@@ -35,6 +38,7 @@ module "l3" {
 module "l4" {
   source               = "./modules/get_sub_ous"
   include_aws_accounts = var.include_child_accounts
+  include_ou_tags      = var.include_ou_tags
   name_path_delimiter  = var.name_path_delimiter
   parent_level_ou_list = module.l3.list
 }
@@ -42,6 +46,7 @@ module "l4" {
 module "l5" {
   source               = "./modules/get_sub_ous"
   include_aws_accounts = var.include_child_accounts
+  include_ou_tags      = var.include_ou_tags
   name_path_delimiter  = var.name_path_delimiter
   parent_level_ou_list = module.l4.list
 }

--- a/modules/data/modules/get_sub_ous/variables.tf
+++ b/modules/data/modules/get_sub_ous/variables.tf
@@ -3,6 +3,11 @@ variable "include_aws_accounts" {
   type        = bool
 }
 
+variable "include_ou_tags" {
+  description = "Include tags for each OU in the output, increases the number of API calls when enabled."
+  type        = bool
+}
+
 variable "name_path_delimiter" {
   description = "Delimiter used to join names in the name_path attribute of each OU."
   type        = string

--- a/modules/data/variables.tf
+++ b/modules/data/variables.tf
@@ -15,6 +15,12 @@ variable "include_descendant_accounts" {
   }
 }
 
+variable "include_ou_tags" {
+  description = "Include tags for each OU in the output, increases the number of API calls when enabled."
+  type        = bool
+  default     = false
+}
+
 variable "name_path_delimiter" {
   description = "Delimiter used to join names in the name_path attribute of each OU."
   type        = string

--- a/modules/resource/README.md
+++ b/modules/resource/README.md
@@ -26,6 +26,7 @@ Each OU is represented as a map with attributes
 - `name_path` - Path to the OU using OU names, delimited by the `name_path_delimiter` variable.
 - `org_path` - Path to the OU from the Organization ID, to be used with the `aws:PrincipalOrgPaths` and `aws:ResourceOrgPaths` conditions.
 - `parent_id` - ID of the OU's direct parent.
+- `tags` - Map of tags associated with the OU.
 
 ## Usage
 
@@ -67,51 +68,50 @@ resource "aws_organizations_policy_attachment" "scp" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version   |
-| ------------------------------------------------------------------------ | --------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.10.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 4.55.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.55.0 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | 5.96.0  |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.55.0 |
 
 ## Modules
 
-| Name                                      | Source             | Version |
-| ----------------------------------------- | ------------------ | ------- |
-| <a name="module_l1"></a> [l1](#module_l1) | ./modules/ou_level | n/a     |
-| <a name="module_l2"></a> [l2](#module_l2) | ./modules/ou_level | n/a     |
-| <a name="module_l3"></a> [l3](#module_l3) | ./modules/ou_level | n/a     |
-| <a name="module_l4"></a> [l4](#module_l4) | ./modules/ou_level | n/a     |
-| <a name="module_l5"></a> [l5](#module_l5) | ./modules/ou_level | n/a     |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_l1"></a> [l1](#module\_l1) | ./modules/ou_level | n/a |
+| <a name="module_l2"></a> [l2](#module\_l2) | ./modules/ou_level | n/a |
+| <a name="module_l3"></a> [l3](#module\_l3) | ./modules/ou_level | n/a |
+| <a name="module_l4"></a> [l4](#module\_l4) | ./modules/ou_level | n/a |
+| <a name="module_l5"></a> [l5](#module\_l5) | ./modules/ou_level | n/a |
 
 ## Resources
 
-| Name                                                                                                                                            | Type        |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Name | Type |
+|------|------|
 | [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs
 
-| Name                                                                                                               | Description                                                                                      | Type     | Default | Required |
-| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------- | ------- | :------: |
-| <a name="input_include_child_accounts"></a> [include_child_accounts](#input_include_child_accounts)                | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool`   | `false` |    no    |
-| <a name="input_include_descendant_accounts"></a> [include_descendant_accounts](#input_include_descendant_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled.                | `bool`   | `false` |    no    |
-| <a name="input_name_path_delimiter"></a> [name_path_delimiter](#input_name_path_delimiter)                         | Delimiter used to join names in the name_path attribute of each OU.                              | `string` | `"/"`   |    no    |
-| <a name="input_organization_structure"></a> [organization_structure](#input_organization_structure)                | The structure of OUs to manage as a map of maps.                                                 | `any`    | n/a     |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_include_child_accounts"></a> [include\_child\_accounts](#input\_include\_child\_accounts) | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
+| <a name="input_include_descendant_accounts"></a> [include\_descendant\_accounts](#input\_include\_descendant\_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled. | `bool` | `false` | no |
+| <a name="input_name_path_delimiter"></a> [name\_path\_delimiter](#input\_name\_path\_delimiter) | Delimiter used to join names in the name\_path attribute of each OU. | `string` | `"/"` | no |
+| <a name="input_organization_structure"></a> [organization\_structure](#input\_organization\_structure) | The structure of OUs to manage as a map of maps. | `any` | n/a | yes |
+| <a name="input_ou_tags_key"></a> [ou\_tags\_key](#input\_ou\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. | `string` | `null` | no |
 
 ## Outputs
 
-| Name                                                                    | Description                                                       |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| <a name="output_by_id"></a> [by_id](#output_by_id)                      | Map of managed OUs indexed by id.                                 |
-| <a name="output_by_name_path"></a> [by_name_path](#output_by_name_path) | Map of managed OUs indexed by name_path.                          |
-| <a name="output_list"></a> [list](#output_list)                         | List of managed OUs with added attributes name_path and org_path. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_by_id"></a> [by\_id](#output\_by\_id) | Map of managed OUs indexed by id. |
+| <a name="output_by_name_path"></a> [by\_name\_path](#output\_by\_name\_path) | Map of managed OUs indexed by name\_path. |
+| <a name="output_list"></a> [list](#output\_list) | List of managed OUs with added attributes name\_path and org\_path. |
 <!-- END_TF_DOCS -->

--- a/modules/resource/README.md
+++ b/modules/resource/README.md
@@ -4,6 +4,7 @@ An open-source Terraform module to **manage** AWS Organizations Organizational U
 
 - Supports up to **5 levels** of Organizational Units (AWS Quota).
 - Define your organization structure as a map.
+- Tag each OU and cascade tags to child OUs.
 - Generates OrgPaths, to be used with the `aws:PrincipalOrgPaths` and `aws:ResourceOrgPaths` IAM conditions.
 - Organizational Units are exposed via a list and indexed maps, see <a name="Outputs"></a> [Outputs](#Outputs) for more information.
 
@@ -101,11 +102,12 @@ resource "aws_organizations_policy_attachment" "scp" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cascading_tags_key"></a> [cascading\_tags\_key](#input\_cascading\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. These tags will cascade to child OUs if the same key isn't defined on a nested OU. | `string` | `""` | no |
 | <a name="input_include_child_accounts"></a> [include\_child\_accounts](#input\_include\_child\_accounts) | Include direct child AWS accounts in the output, increases the number of API calls when enabled. | `bool` | `false` | no |
 | <a name="input_include_descendant_accounts"></a> [include\_descendant\_accounts](#input\_include\_descendant\_accounts) | Include descendant AWS accounts in the output, increases complexity when enabled. | `bool` | `false` | no |
 | <a name="input_name_path_delimiter"></a> [name\_path\_delimiter](#input\_name\_path\_delimiter) | Delimiter used to join names in the name\_path attribute of each OU. | `string` | `"/"` | no |
 | <a name="input_organization_structure"></a> [organization\_structure](#input\_organization\_structure) | The structure of OUs to manage as a map of maps. | `any` | n/a | yes |
-| <a name="input_ou_tags_key"></a> [ou\_tags\_key](#input\_ou\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags for the OU. | `string` | `null` | no |
+| <a name="input_static_tags_key"></a> [static\_tags\_key](#input\_static\_tags\_key) | A key that will be ignored within organization\_structure, and will instead be used to define a map of tags on the OU. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/resource/main.tf
+++ b/modules/resource/main.tf
@@ -8,40 +8,78 @@ locals {
   root_id         = data.aws_organizations_organization.org.roots[0].id
   org_path_prefix = "${local.org_id}/${local.root_id}/"
 
-  # Convert the nested map structure into a flat list of name paths - "Level 1:::Level 2:::Level 3:::Level 4:::Level 5"
+  # Convert the nested map structure into a map of objects with paths and tags
+  # { "Level1:::Level2:::Level3:::Level4:::Level5" : {"tags": {"key": "value"} }
   # Terraform can't do recursion, so we have to do this manually.
-  ou_list = flatten([
-    for l1_k, l1_v in var.organization_structure : [
-      l1_k,
-      [
-        for l2_k, l2_v in try(l1_v, {}) : [
-          join(local.internal_name_path_delimiter, [l1_k, l2_k]),
-          [
-            for l3_k, l3_v in try(l2_v, {}) : [
-              join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k]),
-              [
-                for l4_k, l4_v in try(l3_v, {}) : [
-                  join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k, l4_k]),
-                  [
-                    for l5_k, l5_v in try(l4_v, {}) : [
-                      join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k, l4_k, l5_k])
-                    ]
-                  ]
-                ]
-              ]
-            ]
-          ]
-        ]
-      ]
-    ]
-  ])
+  ous_to_create = {
+    for ou_path in concat(
+      # Level 1
+      [for l1_k, l1_v in var.organization_structure : {
+        path = l1_k
+        tags = var.ou_tags_key != null ? try(l1_v[var.ou_tags_key], {}) : {}
+      }],
+      # Level 2
+      flatten([for l1_k, l1_v in var.organization_structure :
+        [for l2_k, l2_v in try(l1_v, {}) : {
+          path = join(local.internal_name_path_delimiter, [l1_k, l2_k])
+          tags = var.ou_tags_key != null ? try(l2_v[var.ou_tags_key], {}) : {}
+        } if l2_k != var.ou_tags_key]
+      ]),
+      # Level 3
+      flatten([for l1_k, l1_v in var.organization_structure :
+        flatten([for l2_k, l2_v in try(l1_v, {}) :
+          [for l3_k, l3_v in try(l2_v, {}) : {
+            path = join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k])
+            tags = var.ou_tags_key != null ? try(l3_v[var.ou_tags_key], {}) : {}
+          } if l3_k != var.ou_tags_key]
+          if l2_k != var.ou_tags_key
+        ])
+      ]),
+      # Level 4
+      flatten([for l1_k, l1_v in var.organization_structure :
+        flatten([for l2_k, l2_v in try(l1_v, {}) :
+          flatten([for l3_k, l3_v in try(l2_v, {}) :
+            [for l4_k, l4_v in try(l3_v, {}) : {
+              path = join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k, l4_k])
+              tags = var.ou_tags_key != null ? try(l4_v[var.ou_tags_key], {}) : {}
+            } if l4_k != var.ou_tags_key]
+            if l3_k != var.ou_tags_key
+          ])
+          if l2_k != var.ou_tags_key
+        ])
+      ]),
+      # Level 5
+      flatten([for l1_k, l1_v in var.organization_structure :
+        flatten([for l2_k, l2_v in try(l1_v, {}) :
+          flatten([for l3_k, l3_v in try(l2_v, {}) :
+            flatten([for l4_k, l4_v in try(l3_v, {}) :
+              [for l5_k, l5_v in try(l4_v, {}) : {
+                path = join(local.internal_name_path_delimiter, [l1_k, l2_k, l3_k, l4_k, l5_k])
+                tags = var.ou_tags_key != null ? try(l5_v[var.ou_tags_key], {}) : {}
+              } if l5_k != var.ou_tags_key]
+              if l4_k != var.ou_tags_key
+            ])
+            if l3_k != var.ou_tags_key
+          ])
+          if l2_k != var.ou_tags_key
+        ])
+      ])
+      ) : ou_path.path => {
+      tags = ou_path.tags
+    }
+  }
+
 }
+
+# Create the OUs
+
+#[for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 1)) if length(split(local.internal_name_path_delimiter, i)) >= 1]
 
 module "l1" {
   source               = "./modules/ou_level"
   include_aws_accounts = var.include_child_accounts
   name_path_delimiter  = local.internal_name_path_delimiter
-  ou_name_paths        = [for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 1)) if length(split(local.internal_name_path_delimiter, i)) >= 1]
+  ous                  = { for k, v in local.ous_to_create : k => v if length(split(local.internal_name_path_delimiter, k)) == 1 }
   # Mock a "l0" module output for the root.
   parent_level_ou_map = { "Root" = {
     id        = local.root_id
@@ -54,7 +92,7 @@ module "l2" {
   source               = "./modules/ou_level"
   include_aws_accounts = var.include_child_accounts
   name_path_delimiter  = local.internal_name_path_delimiter
-  ou_name_paths        = [for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 2)) if length(split(local.internal_name_path_delimiter, i)) >= 2]
+  ous                  = { for k, v in local.ous_to_create : k => v if length(split(local.internal_name_path_delimiter, k)) == 2 }
   parent_level_ou_map  = module.l1.map
 }
 
@@ -62,7 +100,7 @@ module "l3" {
   source               = "./modules/ou_level"
   include_aws_accounts = var.include_child_accounts
   name_path_delimiter  = local.internal_name_path_delimiter
-  ou_name_paths        = [for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 3)) if length(split(local.internal_name_path_delimiter, i)) >= 3]
+  ous                  = { for k, v in local.ous_to_create : k => v if length(split(local.internal_name_path_delimiter, k)) == 3 }
   parent_level_ou_map  = module.l2.map
 }
 
@@ -70,7 +108,7 @@ module "l4" {
   source               = "./modules/ou_level"
   include_aws_accounts = var.include_child_accounts
   name_path_delimiter  = local.internal_name_path_delimiter
-  ou_name_paths        = [for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 4)) if length(split(local.internal_name_path_delimiter, i)) >= 4]
+  ous                  = { for k, v in local.ous_to_create : k => v if length(split(local.internal_name_path_delimiter, k)) == 4 }
   parent_level_ou_map  = module.l3.map
 }
 
@@ -78,7 +116,7 @@ module "l5" {
   source               = "./modules/ou_level"
   include_aws_accounts = var.include_child_accounts
   name_path_delimiter  = local.internal_name_path_delimiter
-  ou_name_paths        = [for i in local.ou_list : join(local.internal_name_path_delimiter, slice(split(local.internal_name_path_delimiter, i), 0, 5)) if length(split(local.internal_name_path_delimiter, i)) >= 5]
+  ous                  = { for k, v in local.ous_to_create : k => v if length(split(local.internal_name_path_delimiter, k)) == 5 }
   parent_level_ou_map  = module.l4.map
 }
 

--- a/modules/resource/modules/ou_level/main.tf
+++ b/modules/resource/modules/ou_level/main.tf
@@ -3,9 +3,10 @@ locals {
 }
 
 resource "aws_organizations_organizational_unit" "ous" {
-  for_each  = toset(var.ou_name_paths)
+  for_each  = var.ous
   name      = element(split(var.name_path_delimiter, each.key), -1)
   parent_id = local.is_level1 ? var.parent_level_ou_map["Root"].id : var.parent_level_ou_map[trimsuffix(each.key, "${var.name_path_delimiter}${element(split(var.name_path_delimiter, each.key), -1)}")].id
+  tags      = each.value.tags
 }
 
 locals {
@@ -23,6 +24,7 @@ locals {
     name_path           = name_path
     org_path            = local.is_level1 ? "${var.parent_level_ou_map["Root"].org_path}${ou.id}/" : join("", [var.parent_level_ou_map[trimsuffix(name_path, "${var.name_path_delimiter}${element(split(var.name_path_delimiter, name_path), -1)}")].org_path, ou.id, "/"])
     parent_id           = ou.parent_id
+    tags                = ou.tags_all
     }
   }
 }

--- a/modules/resource/modules/ou_level/variables.tf
+++ b/modules/resource/modules/ou_level/variables.tf
@@ -8,9 +8,11 @@ variable "name_path_delimiter" {
   type        = string
 }
 
-variable "ou_name_paths" {
-  description = "A list of OU paths for the OUs to create at the current level."
-  type        = list(string)
+variable "ous" {
+  description = "A map ( name_path => {tags: {}} ) of the OUs to create at the current level."
+  type = map(object({
+    tags = optional(map(string))
+  }))
 }
 
 variable "parent_level_ou_map" {

--- a/modules/resource/variables.tf
+++ b/modules/resource/variables.tf
@@ -34,3 +34,14 @@ variable "organization_structure" {
     error_message = "OU names cannot contain \"${local.internal_name_path_delimiter}\" as this is used within the module to separate levels."
   }
 }
+
+variable "ou_tags_key" {
+  description = "A key that will be ignored within organization_structure, and will instead be used to define a map of tags for the OU."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.ou_tags_key != null ? length(var.organization_structure) > 0 : true
+    error_message = "ou_tags_key can only be set if organization_structure is provided."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,14 @@
+variable "cascading_tags_key" {
+  description = "A key that will be ignored within organization_structure, and will instead be used to define a map of tags for the OU. These tags will cascade to child OUs if the same key isn't defined on a nested OU."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.cascading_tags_key != "" ? length(var.organization_structure) > 0 : true
+    error_message = "cascading_tags_key can only be set if organization_structure is provided."
+  }
+}
+
 variable "include_child_accounts" {
   description = "Include direct child AWS accounts in the output, increases the number of API calls when enabled."
   type        = bool
@@ -31,20 +42,15 @@ variable "organization_structure" {
   description = "The structure of OUs to manage as a map of maps. If not provided, this module will function as a data source."
   type        = any
   default     = {}
-
-  validation {
-    condition     = !strcontains(jsonencode(var.organization_structure), var.name_path_delimiter)
-    error_message = "OU names cannot contain the name_path_delimiter."
-  }
 }
 
-variable "ou_tags_key" {
-  description = "A key that will be ignored within organization_structure, and will instead be used to define a map of tags for the OU."
+variable "static_tags_key" {
+  description = "A key that will be ignored within organization_structure, and will instead be used to define a map of tags on the OU."
   type        = string
-  default     = null
+  default     = ""
 
   validation {
-    condition     = var.ou_tags_key != null ? length(var.organization_structure) > 0 : true
-    error_message = "ou_tags_key can only be set if organization_structure is provided."
+    condition     = var.static_tags_key != "" ? length(var.organization_structure) > 0 : true
+    error_message = "static_tags_key can only be set if organization_structure is provided."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "include_descendant_accounts" {
   }
 }
 
+variable "include_ou_tags" {
+  description = "Include tags for each OU in the output, increases the number of API calls when enabled. Has no effect when organization_structure is provided."
+  type        = bool
+  default     = false
+}
+
 variable "name_path_delimiter" {
   description = "Delimiter used to join names in the name_path attribute of each OU."
   type        = string
@@ -29,5 +35,16 @@ variable "organization_structure" {
   validation {
     condition     = !strcontains(jsonencode(var.organization_structure), var.name_path_delimiter)
     error_message = "OU names cannot contain the name_path_delimiter."
+  }
+}
+
+variable "ou_tags_key" {
+  description = "A key that will be ignored within organization_structure, and will instead be used to define a map of tags for the OU."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.ou_tags_key != null ? length(var.organization_structure) > 0 : true
+    error_message = "ou_tags_key can only be set if organization_structure is provided."
   }
 }


### PR DESCRIPTION
Adds support for OU tags within the module. When used as a resource, tags can be added directly to a single OU ("static") or to an OU and it's descendants ("cascading").  When enabled, tags are fetched when retrieving the OU structure as a data source.