### PR TITLE
Fix module outputs being unknown when changing organization structure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,5 +22,5 @@ module "resource" {
 }
 
 locals {
-  output_map = try(module.data[0].by_name_path, module.resource[0].by_name_path)
+  output_map = !local.is_resource ? module.data[0].by_name_path : module.resource[0].by_name_path
 }


### PR DESCRIPTION
When the module is used as a resource, the evaluation of the `try` function causes all outputs that are based on `local.output_map` to become `(known after apply)` when the OU structure is changed. Removing the `try` function enables the module to output the expected structures with specific values as unknown.

## Example

Given an existing deployment as
```hcl
module "ous" {
  source = "nationalarchives/organizations-ous-by-path/aws"
  organization_structure = {
    "Level1" = {
      "Level2" = {}
    }
  }
}

output "a" {
  value = module.ous
}
```

Adding a new OU at `Level1/Level2/Level3` and planning gives

```
Changes to Outputs:
  + a = {
      + by_id        = (known after apply)
      + by_name_path = (known after apply)
      + list         = (known after apply)
    }
```

This prevents the module caller using the new OU without first applying the change to the module.

With this change, only the unknown values remain unknown in the output and Terraform is smart enough to use these track these within the dependency graph, allowing the new OU to be used immediately. Such as, as the `target_id` within a `aws_organizations_policy_attachment` resource.

```
Changes to Outputs:
  + a = {
      + by_id        = (known after apply)
      + by_name_path = {
          + Level1                 = {
              + arn                 = "arn:aws:organizations::111111111111:ou/o-abcdefghi0/ou-5abc-1i9g32lo"
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = "ou-5abc-1i9g32lo"
              + name                = "Level1"
              + name_path           = "Level1"
              + org_path            = "o-abcdefghi0/r-5abc/ou-5abc-1i9g32lo/"
              + parent_id           = "r-5abc"
            }
          + "Level1/Level2"        = {
              + arn                 = "arn:aws:organizations::111111111111:ou/o-abcdefghi0/ou-5abc-azig0737"
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = "ou-5abc-azig0737"
              + name                = "Level2"
              + name_path           = "Level1/Level2"
              + org_path            = "o-abcdefghi0/r-5abc/ou-5abc-1i9g32lo/ou-5abc-azig0737/"
              + parent_id           = "ou-5abc-1i9g32lo"
            }
          + "Level1/Level2/Level3" = {
              + arn                 = (known after apply)
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = (known after apply)
              + name                = "Level3"
              + name_path           = "Level1/Level2/Level3"
              + org_path            = (known after apply)
              + parent_id           = "ou-5abc-azig0737"
            }
        }
      + list         = [
          + {
              + arn                 = "arn:aws:organizations::111111111111:ou/o-abcdefghi0/ou-5abc-1i9g32lo"
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = "ou-5abc-1i9g32lo"
              + name                = "Level1"
              + name_path           = "Level1"
              + org_path            = "o-abcdefghi0/r-5abc/ou-5abc-1i9g32lo/"
              + parent_id           = "r-5abc"
            },
          + {
              + arn                 = "arn:aws:organizations::111111111111:ou/o-abcdefghi0/ou-5abc-azig0737"
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = "ou-5abc-azig0737"
              + name                = "Level2"
              + name_path           = "Level1/Level2"
              + org_path            = "o-abcdefghi0/r-5abc/ou-5abc-1i9g32lo/ou-5abc-azig0737/"
              + parent_id           = "ou-5abc-1i9g32lo"
            },
          + {
              + arn                 = (known after apply)
              + child_accounts      = []
              + descendant_accounts = []
              + id                  = (known after apply)
              + name                = "Level3"
              + name_path           = "Level1/Level2/Level3"
              + org_path            = (known after apply)
              + parent_id           = "ou-5abc-azig0737"
            },
        ]
    }
```
