### PR TITLE
Replace Dependabot with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>nationalarchives/renovate-config",
-    "github>nationalarchives/renovate-config:github-actions",
-    "github>nationalarchives/renovate-config:terraform-providers"
+    "github>nationalarchives/renovate-config:github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>nationalarchives/renovate-config",
+    "github>nationalarchives/renovate-config:github-actions",
+    "github>nationalarchives/renovate-config:terraform-providers"
+  ]
+}


### PR DESCRIPTION
Remove `.github/dependabot.yml` and add `renovate.json` pointing to the centralised [nationalarchives/renovate-config](https://github.com/nationalarchives/renovate-config) shared presets.

## Presets used

- **default** — base settings, dashboard, OSV vulnerability alerts
- **github-actions** — SHA-pin external actions, automerge, 7-day cooldown
- **terraform-providers** — automerge minor/patch, manual review for major