### PR TITLE
Exclude Terraform AWS provider from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>nationalarchives/renovate-config",
-    "github>nationalarchives/renovate-config:github-actions"
+    "local>nationalarchives/renovate-config",
+    "local>nationalarchives/renovate-config:github-actions"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "local>nationalarchives/renovate-config",
     "local>nationalarchives/renovate-config:github-actions"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["terraform"],
+      "matchPackageNames": ["hashicorp/aws"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The Terraform AWS provider version should only be updated when needed, in which case it should be done manually by the developer.