### PR TITLE
Fix descendant_accounts containing accounts from OUs with similar ID strings

### DIFF
--- a/modules/data/main.tf
+++ b/modules/data/main.tf
@@ -64,6 +64,6 @@ locals {
   )
 
   output_list = !var.include_descendant_accounts ? local.all_ous : [for ou in local.all_ous : merge(ou, {
-    descendant_accounts = flatten([for i in local.all_ous : i.child_accounts if strcontains(i.org_path, ou.id)])
+    descendant_accounts = flatten([for i in local.all_ous : i.child_accounts if strcontains(i.org_path, "/${ou.id}/")])
   })]
 }

--- a/modules/resource/main.tf
+++ b/modules/resource/main.tf
@@ -160,7 +160,7 @@ locals {
   output_map = { for name_path, ou in local.all_ous_internal : replace(ou.name_path, local.internal_name_path_delimiter, var.name_path_delimiter) => merge(
     ou,
     { name_path = replace(ou.name_path, local.internal_name_path_delimiter, var.name_path_delimiter) },
-    !var.include_descendant_accounts ? {} : { descendant_accounts = flatten([for i in local.all_ous_internal : i.child_accounts if strcontains(i.org_path, ou.id)]) }
+    !var.include_descendant_accounts ? {} : { descendant_accounts = flatten([for i in local.all_ous_internal : i.child_accounts if strcontains(i.org_path, "/${ou.id}/")]) }
     )
   }
 }


### PR DESCRIPTION
Fix finding from AI review.
> org_path is org/root/ou-a/ou-b/ . AWS OU ids share a prefix and vary 8–32 chars, so one id can be a substring of another (e.g.  ou-ab12-cdef  ⊂  ou-ab12-cdef99 ). A bare  strcontains  would then wrongly fold the longer OU's accounts into the shorter one.